### PR TITLE
Implement drive input support

### DIFF
--- a/build/form.js
+++ b/build/form.js
@@ -26,13 +26,15 @@ THE SOFTWARE.
 /**
  * @module form
  */
-var Promise, inquirer, utils, _;
+var Promise, inquirer, utils, visuals, _;
 
 Promise = require('bluebird');
 
 _ = require('lodash');
 
 inquirer = require('inquirer');
+
+visuals = require('resin-cli-visuals');
 
 utils = require('./utils');
 
@@ -62,11 +64,13 @@ utils = require('./utils');
  */
 
 exports.run = function(form) {
-  return Promise.fromNode(function(callback) {
-    return inquirer.prompt(utils.parse(form), function(answers) {
-      return callback(null, answers);
+  var questions;
+  questions = utils.parse(form);
+  return Promise.reduce(questions, function(answers, question) {
+    return utils.prompt([question]).then(function(answer) {
+      return _.assign(answers, answer);
     });
-  });
+  }, {});
 };
 
 

--- a/build/form.js
+++ b/build/form.js
@@ -67,9 +67,16 @@ exports.run = function(form) {
   var questions;
   questions = utils.parse(form);
   return Promise.reduce(questions, function(answers, question) {
-    return utils.prompt([question]).then(function(answer) {
-      return _.assign(answers, answer);
-    });
+    if (question.type === 'drive') {
+      return visuals.drive(question.message).then(function(drive) {
+        answers[question.name] = drive;
+        return answers;
+      });
+    } else {
+      return utils.prompt([question]).then(function(answer) {
+        return _.assign(answers, answer);
+      });
+    }
   }, {});
 };
 

--- a/build/utils.js
+++ b/build/utils.js
@@ -22,9 +22,13 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
  */
-var _;
+var Promise, inquirer, _;
+
+Promise = require('bluebird');
 
 _ = require('lodash');
+
+inquirer = require('inquirer');
 
 
 /**
@@ -101,5 +105,39 @@ exports.parse = function(form) {
       };
     }
     return result;
+  });
+};
+
+
+/**
+ * @summary Prompt a questions form
+ * @function
+ * @protected
+ *
+ * @param {Object[]} questions - form questions
+ * @returns {Promise<Object>} answers
+ *
+ * @example
+ * utils.prompt [
+ * 	message: 'Processor'
+ * 	name: 'processorType'
+ * 	type: 'list'
+ * 	choices: [ 'Z7010', 'Z7020' ]
+ * ,
+ * 	message: 'Coprocessor cores'
+ * 	name: 'coprocessorCore'
+ * 	type: 'list'
+ * 	values: [ '16', '64' ]
+ * ]
+ * .then (answers) ->
+ * 	console.log(answers.processorType)
+ * 	console.log(answers.coprocessorCore)
+ */
+
+exports.prompt = function(questions) {
+  return Promise.fromNode(function(callback) {
+    return inquirer.prompt(questions, function(answers) {
+      return callback(null, answers);
+    });
   });
 };

--- a/lib/form.coffee
+++ b/lib/form.coffee
@@ -59,8 +59,13 @@ exports.run = (form) ->
 	questions = utils.parse(form)
 
 	Promise.reduce questions, (answers, question) ->
-		utils.prompt([ question ]).then (answer) ->
-			return _.assign(answers, answer)
+		if question.type is 'drive'
+			visuals.drive(question.message).then (drive) ->
+				answers[question.name] = drive
+				return answers
+		else
+			utils.prompt([ question ]).then (answer) ->
+				return _.assign(answers, answer)
 	, {}
 
 ###*

--- a/lib/form.coffee
+++ b/lib/form.coffee
@@ -29,6 +29,7 @@ THE SOFTWARE.
 Promise = require('bluebird')
 _ = require('lodash')
 inquirer = require('inquirer')
+visuals = require('resin-cli-visuals')
 utils = require('./utils')
 
 ###*
@@ -55,9 +56,12 @@ utils = require('./utils')
 # 	console.log(answers)
 ###
 exports.run = (form) ->
-	Promise.fromNode (callback) ->
-		inquirer.prompt utils.parse(form), (answers) ->
-			return callback(null, answers)
+	questions = utils.parse(form)
+
+	Promise.reduce questions, (answers, question) ->
+		utils.prompt([ question ]).then (answer) ->
+			return _.assign(answers, answer)
+	, {}
 
 ###*
 # @summary Run a single form question

--- a/lib/utils.coffee
+++ b/lib/utils.coffee
@@ -22,7 +22,9 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 ###
 
+Promise = require('bluebird')
 _ = require('lodash')
+inquirer = require('inquirer')
 
 ###*
 # @summary Flatten form groups
@@ -92,3 +94,32 @@ exports.parse = (form) ->
 				return _.findWhere([ answers ], option.when)?
 
 		return result
+
+###*
+# @summary Prompt a questions form
+# @function
+# @protected
+#
+# @param {Object[]} questions - form questions
+# @returns {Promise<Object>} answers
+#
+# @example
+# utils.prompt [
+# 	message: 'Processor'
+# 	name: 'processorType'
+# 	type: 'list'
+# 	choices: [ 'Z7010', 'Z7020' ]
+# ,
+# 	message: 'Coprocessor cores'
+# 	name: 'coprocessorCore'
+# 	type: 'list'
+# 	values: [ '16', '64' ]
+# ]
+# .then (answers) ->
+# 	console.log(answers.processorType)
+# 	console.log(answers.coprocessorCore)
+###
+exports.prompt = (questions) ->
+	Promise.fromNode (callback) ->
+		inquirer.prompt questions, (answers) ->
+			return callback(null, answers)

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
   "dependencies": {
     "bluebird": "^2.9.30",
     "inquirer": "^0.9.0",
-    "lodash": "^3.9.3"
+    "lodash": "^3.9.3",
+    "resin-cli-visuals": "^1.2.0"
   }
 }

--- a/tests/form.spec.coffee
+++ b/tests/form.spec.coffee
@@ -1,6 +1,7 @@
 m = require('mochainon')
 Promise = require('bluebird')
 inquirer = require('inquirer')
+utils = require('../lib/utils')
 form = require('../lib/form')
 
 describe 'Form:', ->
@@ -8,21 +9,29 @@ describe 'Form:', ->
 	describe '.run()', ->
 
 		beforeEach ->
-			@inquirerPromptStub = m.sinon.stub(inquirer, 'prompt')
-			@inquirerPromptStub.yields({ foo: 'bar' })
+			@utilsPromptStub = m.sinon.stub(utils, 'prompt')
+			@utilsPromptStub.onFirstCall().returns(Promise.resolve(processorType: 'Z7010'))
+			@utilsPromptStub.onSecondCall().returns(Promise.resolve(coprocessorCore: '64'))
 
 		afterEach ->
-			@inquirerPromptStub.restore()
+			@utilsPromptStub.restore()
 
 		it 'should eventually be the result', ->
 			promise = form.run [
-				message: 'Processor'
-				name: 'processorType'
-				type: 'list'
-				choices: [ 'Z7010', 'Z7020' ]
+					message: 'Processor'
+					name: 'processorType'
+					type: 'list'
+					choices: [ 'Z7010', 'Z7020' ]
+				,
+					message: 'Coprocessor cores'
+					name: 'coprocessorCore'
+					type: 'list'
+					choices: [ '16', '64' ]
 			]
 
-			m.chai.expect(promise).to.eventually.become(foo: 'bar')
+			m.chai.expect(promise).to.eventually.become
+				processorType: 'Z7010'
+				coprocessorCore: '64'
 
 	describe '.ask()', ->
 

--- a/tests/form.spec.coffee
+++ b/tests/form.spec.coffee
@@ -1,6 +1,7 @@
 m = require('mochainon')
 Promise = require('bluebird')
 inquirer = require('inquirer')
+visuals = require('resin-cli-visuals')
 utils = require('../lib/utils')
 form = require('../lib/form')
 
@@ -8,30 +9,68 @@ describe 'Form:', ->
 
 	describe '.run()', ->
 
-		beforeEach ->
-			@utilsPromptStub = m.sinon.stub(utils, 'prompt')
-			@utilsPromptStub.onFirstCall().returns(Promise.resolve(processorType: 'Z7010'))
-			@utilsPromptStub.onSecondCall().returns(Promise.resolve(coprocessorCore: '64'))
+		describe 'given a simple form', ->
 
-		afterEach ->
-			@utilsPromptStub.restore()
+			beforeEach ->
+				@utilsPromptStub = m.sinon.stub(utils, 'prompt')
+				@utilsPromptStub.onFirstCall().returns(Promise.resolve(processorType: 'Z7010'))
+				@utilsPromptStub.onSecondCall().returns(Promise.resolve(coprocessorCore: '64'))
 
-		it 'should eventually be the result', ->
-			promise = form.run [
-					message: 'Processor'
-					name: 'processorType'
-					type: 'list'
-					choices: [ 'Z7010', 'Z7020' ]
-				,
-					message: 'Coprocessor cores'
-					name: 'coprocessorCore'
-					type: 'list'
-					choices: [ '16', '64' ]
-			]
+			afterEach ->
+				@utilsPromptStub.restore()
 
-			m.chai.expect(promise).to.eventually.become
-				processorType: 'Z7010'
-				coprocessorCore: '64'
+			it 'should eventually be the result', ->
+				promise = form.run [
+						message: 'Processor'
+						name: 'processorType'
+						type: 'list'
+						choices: [ 'Z7010', 'Z7020' ]
+					,
+						message: 'Coprocessor cores'
+						name: 'coprocessorCore'
+						type: 'list'
+						choices: [ '16', '64' ]
+				]
+
+				m.chai.expect(promise).to.eventually.become
+					processorType: 'Z7010'
+					coprocessorCore: '64'
+
+		describe 'given a form with a drive input', ->
+
+			beforeEach ->
+				@utilsPromptStub = m.sinon.stub(utils, 'prompt')
+				@utilsPromptStub.onFirstCall().returns(Promise.resolve(processorType: 'Z7010'))
+				@utilsPromptStub.onSecondCall().returns(Promise.resolve(coprocessorCore: '64'))
+
+				@visualsDriveStub = m.sinon.stub(visuals, 'drive')
+				@visualsDriveStub.returns(Promise.resolve('/dev/disk2'))
+
+			afterEach ->
+				@utilsPromptStub.restore()
+				@visualsDriveStub.restore()
+
+			it 'should eventually be the result', ->
+				promise = form.run [
+						message: 'Processor'
+						name: 'processorType'
+						type: 'list'
+						choices: [ 'Z7010', 'Z7020' ]
+					,
+						message: 'Select a drive'
+						type: 'drive'
+						name: 'device'
+					,
+						message: 'Coprocessor cores'
+						name: 'coprocessorCore'
+						type: 'list'
+						choices: [ '16', '64' ]
+				]
+
+				m.chai.expect(promise).to.eventually.become
+					processorType: 'Z7010'
+					device: '/dev/disk2'
+					coprocessorCore: '64'
 
 	describe '.ask()', ->
 

--- a/tests/utils.spec.coffee
+++ b/tests/utils.spec.coffee
@@ -228,6 +228,23 @@ describe 'Utils:', ->
 					}
 				]
 
+		describe 'given a drive input', ->
+
+			beforeEach ->
+				@form = [
+					message: 'Select a drive'
+					type: 'drive'
+					name: 'drive'
+				]
+
+			it 'should be parsed correctly', ->
+				questions = utils.parse(@form)
+				m.chai.expect(questions).to.deep.equal [
+					message: 'Select a drive'
+					type: 'drive'
+					name: 'drive'
+				]
+
 	describe '.prompt()', ->
 
 		describe 'given a single question form', ->

--- a/tests/utils.spec.coffee
+++ b/tests/utils.spec.coffee
@@ -1,4 +1,5 @@
 m = require('mochainon')
+inquirer = require('inquirer')
 utils = require('../lib/utils')
 
 describe 'Utils:', ->
@@ -226,3 +227,52 @@ describe 'Utils:', ->
 						choices: [ 'Z7010', 'Z7020' ]
 					}
 				]
+
+	describe '.prompt()', ->
+
+		describe 'given a single question form', ->
+
+			beforeEach ->
+				@inquirerPromptStub = m.sinon.stub(inquirer, 'prompt')
+				@inquirerPromptStub.yields({ processorType: 'bar' })
+
+			afterEach ->
+				@inquirerPromptStub.restore()
+
+			it 'should eventually be the result', ->
+				promise = utils.prompt [
+					message: 'Processor'
+					name: 'processorType'
+					type: 'list'
+					choices: [ 'Z7010', 'Z7020' ]
+				]
+
+				m.chai.expect(promise).to.eventually.become(processorType: 'bar')
+
+		describe 'given a multiple question form', ->
+
+			beforeEach ->
+				@inquirerPromptStub = m.sinon.stub(inquirer, 'prompt')
+				@inquirerPromptStub.yields
+					processorType: 'Z7010'
+					coprocessorCore: '16'
+
+			afterEach ->
+				@inquirerPromptStub.restore()
+
+			it 'should eventually become the answers', ->
+				promise = utils.prompt [
+						message: 'Processor'
+						name: 'processorType'
+						type: 'list'
+						choices: [ 'Z7010', 'Z7020' ]
+					,
+						message: 'Coprocessor cores'
+						name: 'coprocessorCore'
+						type: 'list'
+						choices: [ '16', '64' ]
+				]
+
+				m.chai.expect(promise).to.eventually.become
+					processorType: 'Z7010'
+					coprocessorCore: '16'


### PR DESCRIPTION
This new input has the following syntax:

```
message: 'Select a drive'
type: 'drive'
name: 'drive'
```

and triggers a widget that scans the system for available drives, and
prompts the user to select one.

Currently, this widget makes `form.run()` fail with an error if no
available drives were found, but this will soon change once the widget is
extended to auto detect new plugged devices.
