### PR TITLE
Fix `when` properties not taking effect

### DIFF
--- a/build/form.js
+++ b/build/form.js
@@ -67,6 +67,9 @@ exports.run = function(form) {
   var questions;
   questions = utils.parse(form);
   return Promise.reduce(questions, function(answers, question) {
+    if ((question.shouldPrompt != null) && !question.shouldPrompt(answers)) {
+      return answers;
+    }
     if (question.type === 'drive') {
       return visuals.drive(question.message).then(function(drive) {
         answers[question.name] = drive;

--- a/build/utils.js
+++ b/build/utils.js
@@ -95,9 +95,9 @@ exports.parse = function(form) {
   form = exports.flatten(form);
   return _.map(form, function(option) {
     var result;
-    result = _.cloneDeep(option);
+    result = _.omit(_.cloneDeep(option), 'when');
     if (!_.isEmpty(option.when)) {
-      result.when = function(answers) {
+      result.shouldPrompt = function(answers) {
         if (answers == null) {
           return false;
         }

--- a/lib/form.coffee
+++ b/lib/form.coffee
@@ -59,6 +59,15 @@ exports.run = (form) ->
 	questions = utils.parse(form)
 
 	Promise.reduce questions, (answers, question) ->
+
+		# Since we now run `reduce` over the questions and run
+		# inquirer inputs in an isolated way, `when` functions
+		# no longer make sense to inquirer.
+		# Therefore, we implement `when` checking manually
+		# here based on `shouldPrompt`.
+		if question.shouldPrompt? and not question.shouldPrompt(answers)
+			return answers
+
 		if question.type is 'drive'
 			visuals.drive(question.message).then (drive) ->
 				answers[question.name] = drive

--- a/lib/utils.coffee
+++ b/lib/utils.coffee
@@ -84,12 +84,15 @@ exports.parse = (form) ->
 	form = exports.flatten(form)
 
 	return _.map form, (option) ->
-		result = _.cloneDeep(option)
+
+		# We omit `when` since we internally translate this
+		# into a `shouldPrompt` function instead.
+		result = _.omit(_.cloneDeep(option), 'when')
 
 		# Translate object "when" definitions
 		# to functions we can run and evaluate
 		if not _.isEmpty(option.when)
-			result.when = (answers) ->
+			result.shouldPrompt = (answers) ->
 				return false if not answers?
 				return _.findWhere([ answers ], option.when)?
 

--- a/tests/form.spec.coffee
+++ b/tests/form.spec.coffee
@@ -72,6 +72,62 @@ describe 'Form:', ->
 					device: '/dev/disk2'
 					coprocessorCore: '64'
 
+		describe 'given a form with `when` properties', ->
+
+			beforeEach ->
+				@form = [
+						message: 'Network Connection'
+						name: 'network'
+						type: 'list'
+						choices: [ 'ethernet', 'wifi' ]
+					,
+						message: 'Wifi SSID'
+						name: 'wifiSsid'
+						type: 'text'
+						when:
+							network: 'wifi'
+					,
+						message: 'Wifi Passphrase'
+						name: 'wifiKey'
+						type: 'password'
+						when:
+							network: 'wifi'
+				]
+
+			describe 'given network is ethernet', ->
+
+				beforeEach ->
+					@utilsPromptStub = m.sinon.stub(utils, 'prompt')
+					@utilsPromptStub.onFirstCall().returns(Promise.resolve(network: 'ethernet'))
+					@utilsPromptStub.onSecondCall().returns(Promise.resolve(wifiSsid: 'wifinetwork'))
+					@utilsPromptStub.onThirdCall().returns(Promise.resolve(wifiKey: 'wifipassword'))
+
+				afterEach ->
+					@utilsPromptStub.restore()
+
+				it 'should not ask wifi questions', ->
+					promise = form.run([ @form ])
+					m.chai.expect(promise).to.eventually.become
+						network: 'ethernet'
+
+			describe 'given network is wifi', ->
+
+				beforeEach ->
+					@utilsPromptStub = m.sinon.stub(utils, 'prompt')
+					@utilsPromptStub.onFirstCall().returns(Promise.resolve(network: 'wifi'))
+					@utilsPromptStub.onSecondCall().returns(Promise.resolve(wifiSsid: 'wifinetwork'))
+					@utilsPromptStub.onThirdCall().returns(Promise.resolve(wifiKey: 'wifipassword'))
+
+				afterEach ->
+					@utilsPromptStub.restore()
+
+				it 'should ask wifi questions', ->
+					promise = form.run([ @form ])
+					m.chai.expect(promise).to.eventually.become
+						network: 'wifi'
+						wifiSsid: 'wifinetwork'
+						wifiKey: 'wifipassword'
+
 	describe '.ask()', ->
 
 		describe 'given there is an error running the question', ->

--- a/tests/utils.spec.coffee
+++ b/tests/utils.spec.coffee
@@ -144,26 +144,30 @@ describe 'Utils:', ->
 							processorType: 'Z7010'
 					]
 
-				it 'should return a when function', ->
+				it 'should return a shouldPrompt function', ->
 					questions = utils.parse(@form)
-					m.chai.expect(questions[0].when).to.be.a('function')
+					m.chai.expect(questions[0].shouldPrompt).to.be.a('function')
 
 				it 'should return true if the condition is met', ->
 					questions = utils.parse(@form)
-					m.chai.expect(questions[0].when(processorType: 'Z7010')).to.be.true
+					m.chai.expect(questions[0].shouldPrompt(processorType: 'Z7010')).to.be.true
 
 				it 'should return false if the condition is not met', ->
 					questions = utils.parse(@form)
-					m.chai.expect(questions[0].when(processorType: 'Z7020')).to.be.false
+					m.chai.expect(questions[0].shouldPrompt(processorType: 'Z7020')).to.be.false
 
 				it 'should return false if the property does not exist', ->
 					questions = utils.parse(@form)
-					m.chai.expect(questions[0].when(foo: 'Z7020')).to.be.false
+					m.chai.expect(questions[0].shouldPrompt(foo: 'Z7020')).to.be.false
 
 				it 'should return false if no answer', ->
 					questions = utils.parse(@form)
-					m.chai.expect(questions[0].when()).to.be.false
-					m.chai.expect(questions[0].when({})).to.be.false
+					m.chai.expect(questions[0].shouldPrompt()).to.be.false
+					m.chai.expect(questions[0].shouldPrompt({})).to.be.false
+
+				it 'should not have a when property', ->
+					questions = utils.parse(@form)
+					m.chai.expect(questions[0].when).to.not.exist
 
 			describe 'given a multiple value when', ->
 
@@ -180,11 +184,11 @@ describe 'Utils:', ->
 
 				it 'should return true if all the conditions are met', ->
 					questions = utils.parse(@form)
-					m.chai.expect(questions[0].when(processorType: 'Z7010', hdmi: true)).to.be.true
+					m.chai.expect(questions[0].shouldPrompt(processorType: 'Z7010', hdmi: true)).to.be.true
 
 				it 'should return false if any condition is not met', ->
 					questions = utils.parse(@form)
-					m.chai.expect(questions[0].when(processorType: 'Z7020', hdmi: false)).to.be.false
+					m.chai.expect(questions[0].shouldPrompt(processorType: 'Z7020', hdmi: false)).to.be.false
 
 		describe 'given a form group', ->
 


### PR DESCRIPTION
Before, questions were passed as a whole to `inquirer`, which
understands `when` properties based on the answers to the other passed
questions.

Now, in order to be able to implement the `drive` input, we fold the
questions and pass them in isolation to inquirer, therefore, inquirer
doesn't have enough context anymore to be able to understand `when`
properties.

Solution:
- Check if a question should be asked or not ourselves.
- Since we need to make sure no `when` property arrives to inquirer
  (since it can erroneusly be evaluated to false), we change `when` to
  `shouldPrompt` internally after parsing the questions.
