### PR TITLE
Implement override option

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,19 +27,21 @@ Documentation
 
 
 * [form](#module_form)
-  * [.run(form)](#module_form.run) ⇒ <code>Promise.&lt;Object&gt;</code>
+  * [.run(form, [options])](#module_form.run) ⇒ <code>Promise.&lt;Object&gt;</code>
   * [.ask(question)](#module_form.ask) ⇒ <code>Promise.&lt;\*&gt;</code>
 
 <a name="module_form.run"></a>
-### form.run(form) ⇒ <code>Promise.&lt;Object&gt;</code>
+### form.run(form, [options]) ⇒ <code>Promise.&lt;Object&gt;</code>
 **Kind**: static method of <code>[form](#module_form)</code>  
 **Summary**: Run a form description  
 **Returns**: <code>Promise.&lt;Object&gt;</code> - answers  
 **Access:** public  
 
-| Param | Type | Description |
-| --- | --- | --- |
-| form | <code>Array.&lt;Object&gt;</code> | form description |
+| Param | Type | Default | Description |
+| --- | --- | --- | --- |
+| form | <code>Array.&lt;Object&gt;</code> |  | form description |
+| [options] | <code>Object</code> | <code>{}</code> | options |
+| [options.override] | <code>Object</code> |  | overrides |
 
 **Example**  
 ```js
@@ -53,7 +55,13 @@ form.run [
 	name: 'coprocessorCore'
 	type: 'list'
 	choices: [ '16', '64' ]
-]
+],
+
+	# coprocessorCore will always be 64
+	# Notice that the question will not be asked at all
+	override:
+		coprocessorCore: '64'
+
 .then (answers) ->
 	console.log(answers)
 ```

--- a/build/form.js
+++ b/build/form.js
@@ -45,6 +45,9 @@ utils = require('./utils');
  * @public
  *
  * @param {Object[]} form - form description
+ * @param {Object} [options={}] - options
+ * @param {Object} [options.override] - overrides
+ *
  * @returns {Promise<Object>} answers
  *
  * @example
@@ -58,16 +61,29 @@ utils = require('./utils');
  * 	name: 'coprocessorCore'
  * 	type: 'list'
  * 	choices: [ '16', '64' ]
- * ]
+ * ],
+ *
+ * 	# coprocessorCore will always be 64
+ * 	# Notice that the question will not be asked at all
+ * 	override:
+ * 		coprocessorCore: '64'
+ *
  * .then (answers) ->
  * 	console.log(answers)
  */
 
-exports.run = function(form) {
+exports.run = function(form, options) {
   var questions;
+  if (options == null) {
+    options = {};
+  }
   questions = utils.parse(form);
   return Promise.reduce(questions, function(answers, question) {
     if ((question.shouldPrompt != null) && !question.shouldPrompt(answers)) {
+      return answers;
+    }
+    if (_.has(options.override, question.name) && (_.get(options.override, question.name) != null)) {
+      answers[question.name] = options.override[question.name];
       return answers;
     }
     if (question.type === 'drive') {

--- a/lib/form.coffee
+++ b/lib/form.coffee
@@ -38,6 +38,9 @@ utils = require('./utils')
 # @public
 #
 # @param {Object[]} form - form description
+# @param {Object} [options={}] - options
+# @param {Object} [options.override] - overrides
+#
 # @returns {Promise<Object>} answers
 #
 # @example
@@ -51,11 +54,17 @@ utils = require('./utils')
 # 	name: 'coprocessorCore'
 # 	type: 'list'
 # 	choices: [ '16', '64' ]
-# ]
+# ],
+#
+# 	# coprocessorCore will always be 64
+# 	# Notice that the question will not be asked at all
+# 	override:
+# 		coprocessorCore: '64'
+#
 # .then (answers) ->
 # 	console.log(answers)
 ###
-exports.run = (form) ->
+exports.run = (form, options = {}) ->
 	questions = utils.parse(form)
 
 	Promise.reduce questions, (answers, question) ->
@@ -66,6 +75,10 @@ exports.run = (form) ->
 		# Therefore, we implement `when` checking manually
 		# here based on `shouldPrompt`.
 		if question.shouldPrompt? and not question.shouldPrompt(answers)
+			return answers
+
+		if _.has(options.override, question.name) and _.get(options.override, question.name)?
+			answers[question.name] = options.override[question.name]
 			return answers
 
 		if question.type is 'drive'

--- a/tests/form.spec.coffee
+++ b/tests/form.spec.coffee
@@ -36,6 +36,86 @@ describe 'Form:', ->
 					processorType: 'Z7010'
 					coprocessorCore: '64'
 
+			describe 'given an override option', ->
+
+				it 'should override the selected question', ->
+					promise = form.run [
+							message: 'Processor'
+							name: 'processorType'
+							type: 'list'
+							choices: [ 'Z7010', 'Z7020' ]
+						,
+							message: 'Coprocessor cores'
+							name: 'coprocessorCore'
+							type: 'list'
+							choices: [ '16', '64' ]
+					],
+						override:
+							coprocessorCore: '16'
+
+					m.chai.expect(promise).to.eventually.become
+						processorType: 'Z7010'
+						coprocessorCore: '16'
+
+				it 'should be able to override all questions', ->
+					promise = form.run [
+							message: 'Processor'
+							name: 'processorType'
+							type: 'list'
+							choices: [ 'Z7010', 'Z7020' ]
+						,
+							message: 'Coprocessor cores'
+							name: 'coprocessorCore'
+							type: 'list'
+							choices: [ '16', '64' ]
+					],
+						override:
+							processorType: 'Z7020'
+							coprocessorCore: '16'
+
+					m.chai.expect(promise).to.eventually.become
+						processorType: 'Z7020'
+						coprocessorCore: '16'
+
+				it 'should ignore invalid override options', ->
+					promise = form.run [
+							message: 'Processor'
+							name: 'processorType'
+							type: 'list'
+							choices: [ 'Z7010', 'Z7020' ]
+						,
+							message: 'Coprocessor cores'
+							name: 'coprocessorCore'
+							type: 'list'
+							choices: [ '16', '64' ]
+					],
+						override:
+							foo: 'bar'
+
+					m.chai.expect(promise).to.eventually.become
+						processorType: 'Z7010'
+						coprocessorCore: '64'
+
+				it 'should ignore undefined and null options', ->
+					promise = form.run [
+							message: 'Processor'
+							name: 'processorType'
+							type: 'list'
+							choices: [ 'Z7010', 'Z7020' ]
+						,
+							message: 'Coprocessor cores'
+							name: 'coprocessorCore'
+							type: 'list'
+							choices: [ '16', '64' ]
+					],
+						override:
+							processorType: undefined
+							coprocessorCore: null
+
+					m.chai.expect(promise).to.eventually.become
+						processorType: 'Z7010'
+						coprocessorCore: '64'
+
 		describe 'given a form with a drive input', ->
 
 			beforeEach ->
@@ -70,6 +150,30 @@ describe 'Form:', ->
 				m.chai.expect(promise).to.eventually.become
 					processorType: 'Z7010'
 					device: '/dev/disk2'
+					coprocessorCore: '64'
+
+			it 'should be able to override the drive', ->
+				promise = form.run [
+						message: 'Processor'
+						name: 'processorType'
+						type: 'list'
+						choices: [ 'Z7010', 'Z7020' ]
+					,
+						message: 'Select a drive'
+						type: 'drive'
+						name: 'device'
+					,
+						message: 'Coprocessor cores'
+						name: 'coprocessorCore'
+						type: 'list'
+						choices: [ '16', '64' ]
+				],
+					override:
+						device: '/dev/disk5'
+
+				m.chai.expect(promise).to.eventually.become
+					processorType: 'Z7010'
+					device: '/dev/disk5'
 					coprocessorCore: '64'
 
 		describe 'given a form with `when` properties', ->
@@ -107,6 +211,15 @@ describe 'Form:', ->
 
 				it 'should not ask wifi questions', ->
 					promise = form.run([ @form ])
+					m.chai.expect(promise).to.eventually.become
+						network: 'ethernet'
+
+				it 'should ignore wifi overrides', ->
+					promise = form.run [ @form ],
+						override:
+							wifiSsid: 'foo'
+							wifiKey: 'bar'
+
 					m.chai.expect(promise).to.eventually.become
 						network: 'ethernet'
 


### PR DESCRIPTION
This option allows the client to override questions in the form with
predefined values and avoid the question to be asked interactively.

For example:

```
form.run [
    message: 'What\'s your name?'
    name: 'name'
    type: 'input'
],
    override:
        name: 'Juan Cruz'
.then (answers) ->
    console.log(answers)
```

In the above case, `name` will always equal `Juan Cruz`, and the input
will not even be presented to the user.

The motivation behind this feature is to more easily allow command line
options to override certain asked questions.
