### PR TITLE
Run validations agains overrided questions

### DIFF
--- a/build/form.js
+++ b/build/form.js
@@ -79,11 +79,20 @@ exports.run = function(form, options) {
   }
   questions = utils.parse(form);
   return Promise.reduce(questions, function(answers, question) {
+    var override, validation;
     if ((question.shouldPrompt != null) && !question.shouldPrompt(answers)) {
       return answers;
     }
-    if (_.has(options.override, question.name) && (_.get(options.override, question.name) != null)) {
-      answers[question.name] = options.override[question.name];
+    override = _.get(options.override, question.name);
+    if (override != null) {
+      validation = (question.validate || _.constant(true))(override);
+      if (_.isString(validation)) {
+        throw new Error(validation);
+      }
+      if (!validation) {
+        throw new Error("" + override + " is not a valid " + question.name);
+      }
+      answers[question.name] = override;
       return answers;
     }
     if (question.type === 'drive') {

--- a/lib/form.coffee
+++ b/lib/form.coffee
@@ -77,8 +77,18 @@ exports.run = (form, options = {}) ->
 		if question.shouldPrompt? and not question.shouldPrompt(answers)
 			return answers
 
-		if _.has(options.override, question.name) and _.get(options.override, question.name)?
-			answers[question.name] = options.override[question.name]
+		override = _.get(options.override, question.name)
+
+		if override?
+			validation = (question.validate or _.constant(true))(override)
+
+			if _.isString(validation)
+				throw new Error(validation)
+
+			if not validation
+				throw new Error("#{override} is not a valid #{question.name}")
+
+			answers[question.name] = override
 			return answers
 
 		if question.type is 'drive'

--- a/tests/form.spec.coffee
+++ b/tests/form.spec.coffee
@@ -116,6 +116,47 @@ describe 'Form:', ->
 						processorType: 'Z7010'
 						coprocessorCore: '64'
 
+				it 'should reject with the passed error if validate function returns a string', ->
+					promise = form.run [
+						message: 'username'
+						name: 'username'
+						type: 'input'
+						validate: (input) ->
+							if input.length < 3
+								return 'Username too short'
+							return true
+					],
+						override:
+							username: 'fb'
+
+					m.chai.expect(promise).to.be.rejectedWith('Username too short')
+
+				it 'should reject with a default message if validate function returns false', ->
+					promise = form.run [
+						message: 'username'
+						name: 'username'
+						type: 'input'
+						validate: ->
+							return false
+					],
+						override:
+							username: 'fb'
+
+					m.chai.expect(promise).to.be.rejectedWith('fb is not a valid username')
+
+				it 'should fulfil the answer if validate returns true', ->
+					promise = form.run [
+						message: 'username'
+						name: 'username'
+						type: 'input'
+						validate: ->
+							return true
+					],
+						override:
+							username: 'fb'
+
+					m.chai.expect(promise).to.eventually.deep.equal(username: 'fb')
+
 		describe 'given a form with a drive input', ->
 
 			beforeEach ->


### PR DESCRIPTION
Consider the following example:

``` coffee
form.run [
    message: 'Username'
    name: 'username'
    type: 'input'
    validate: (input) ->
        if input.length < 3
            return 'Username should be at least 3 characters'
        return true
],
    override:
        username: 'fb'
```

This form runs a validate functions agains the username to ensure it's
more than 3 characters, however the fact that we override the username
question means that the value of username is blindly assigned to the
override value, omitting any validation.

The client might rely on the validation of its inputs, and failure of
running those might cause unexpected behaviour in his code.
