### PR TITLE
Upgrade inquirer to v0.11.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   },
   "dependencies": {
     "bluebird": "^2.9.30",
-    "inquirer": "^0.9.0",
+    "inquirer": "^0.11.0",
     "lodash": "^3.9.3",
     "resin-cli-visuals": "^1.2.0"
   }


### PR DESCRIPTION
This version contains a fix that allows prompts to be run under `windosu`.
