### PR TITLE
Allow to pass true to when conditions as an exitencial operator

### DIFF
--- a/build/utils.js
+++ b/build/utils.js
@@ -93,7 +93,14 @@ exports.parse = function(form) {
         if (answers == null) {
           return false;
         }
-        return _.findWhere([answers], option.when) != null;
+        return _.all(_.map(option.when, function(value, key) {
+          var answer;
+          answer = _.get(answers, key);
+          if (value === true && Boolean(answer)) {
+            return true;
+          }
+          return answer === value;
+        }));
       };
     }
     return result;

--- a/lib/utils.coffee
+++ b/lib/utils.coffee
@@ -86,7 +86,15 @@ exports.parse = (form) ->
 		if not _.isEmpty(option.when)
 			result.shouldPrompt = (answers) ->
 				return false if not answers?
-				return _.findWhere([ answers ], option.when)?
+
+				return _.all _.map option.when, (value, key) ->
+					answer = _.get(answers, key)
+
+					# Evaluate `true` as an existencial operator
+					if value is true and Boolean(answer)
+						return true
+
+					return answer is value
 
 		return result
 

--- a/tests/utils.spec.coffee
+++ b/tests/utils.spec.coffee
@@ -190,6 +190,38 @@ describe 'Utils:', ->
 					questions = utils.parse(@form)
 					m.chai.expect(questions[0].shouldPrompt(processorType: 'Z7020', hdmi: false)).to.be.false
 
+			describe 'given a truthy single value when', ->
+
+				beforeEach ->
+					@form = [
+						message: 'Coprocessor cores'
+						name: 'coprocessorCore'
+						type: 'list'
+						choices: [ '16', '64' ]
+						when:
+							processorType: true
+					]
+
+				it 'should return true if the condition value exists', ->
+					questions = utils.parse(@form)
+					m.chai.expect(questions[0].shouldPrompt(processorType: true)).to.be.true
+					m.chai.expect(questions[0].shouldPrompt(processorType: 'Z7010')).to.be.true
+					m.chai.expect(questions[0].shouldPrompt(processorType: 'Z7020')).to.be.true
+
+				it 'should return false if the condition value does not exist', ->
+					questions = utils.parse(@form)
+					m.chai.expect(questions[0].shouldPrompt(foo: 'bar')).to.be.false
+					m.chai.expect(questions[0].shouldPrompt(processorType: undefined)).to.be.false
+					m.chai.expect(questions[0].shouldPrompt(processorType: null)).to.be.false
+
+				it 'should return false if the conditional value is false', ->
+					questions = utils.parse(@form)
+					m.chai.expect(questions[0].shouldPrompt(processorType: false)).to.be.false
+
+				it 'should return false if the conditional value is an empty string', ->
+					questions = utils.parse(@form)
+					m.chai.expect(questions[0].shouldPrompt(processorType: '')).to.be.false
+
 		describe 'given a form group', ->
 
 			beforeEach ->


### PR DESCRIPTION
Currently there is no way to say, "ask this if a value exists,
independently of its value".

The user can now pass `true` to a `when` property to express that a
property should exist.
