### PR TITLE
Add id-token: write permission for NPM OIDC publishing

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -9,6 +9,11 @@ on:
     types: [opened, synchronize, closed]
     branches: [main, master]
 
+permissions:
+  id-token: write
+  contents: read
+  packages: read
+
 jobs:
   flowzone:
     name: Flowzone

--- a/package.json
+++ b/package.json
@@ -4,10 +4,10 @@
   "description": "Resin.io CLI form interpreter",
   "type": "commonjs",
   "main": "build/form.js",
-  "homepage": "https://github.com/resin-io-modules/resin-cli-form",
+  "homepage": "https://github.com/balena-io-modules/resin-cli-form",
   "repository": {
     "type": "git",
-    "url": "git://github.com/resin-io-modules/resin-cli-form.git"
+    "url": "git://github.com/balena-io-modules/resin-cli-form.git"
   },
   "keywords": [
     "resin",


### PR DESCRIPTION
Add `id-token: write` permission to enable NPM publishing via OIDC trusted publishers.
Include `contents: read` and `packages: read` to preserve org default permissions.

Connects-to: https://balena.fibery.io/Work/Improvement/3782

Change-type: patch